### PR TITLE
Set Oracle bin folder in PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN unzip linuxx64_12201_database.zip && \
     /installer/database/runInstaller -ignoresysprereqs -ignoreprereq -waitforcompletion -force -silent ORACLE_HOME=${ORACLE_HOME} ORACLE_HOME_NAME=orcl -responseFile ${ORACLE_BASE}/db_install.rsp  DECLINE_SECURITY_UPDATES=true ORACLE_BASE=${ORACLE_BASE} && \
     rm -rf /installer/* && \
     echo "# fix $ORACLE_HOME/bin/oracle command empty file" && \
-    if [ ! -s ${ORACLE_HOME}/bin/oracl ]; then make -f ${ORACLE_HOME}/rdbms/lib/ins_rdbms.mk javavm_setup_default_jdk; ${ORACLE_HOME}/bin/relink as_installed; fi
+    if [ ! -s ${ORACLE_HOME}/bin/oracle ]; then make -f ${ORACLE_HOME}/rdbms/lib/ins_rdbms.mk javavm_setup_default_jdk; ${ORACLE_HOME}/bin/relink as_installed; fi
 
 FROM oraclelinux:7.2
 
@@ -29,6 +29,7 @@ MAINTAINER eXo Platform <docker@exoplatform.com>
 
 ENV ORACLE_BASE=/u01/app/oracle
 ENV ORACLE_HOME=/u01/app/oracle/product/12.2.0.1/dbhome_1
+ENV PATH=${PATH}:/u01/app/oracle/product/12.2.0.1/dbhome_1/bin
 
 RUN yum -y install oracle-database-server-12cR2-preinstall perl unzip && \
     mkdir -p ${ORACLE_BASE}


### PR DESCRIPTION
Setting the Oracle bin folder in PATH allows to call Oracle tools easily. For example it will allow to use sqlplus, expdp, impdb, ... more easily :

    docker exec oracle sh -c "sqlplus system/plf <<< \"SELECT 1 FROM DUAL;\""